### PR TITLE
Asynchronous input refactoring

### DIFF
--- a/src/combat.rs
+++ b/src/combat.rs
@@ -73,12 +73,13 @@ impl GameState {
 
   fn tick_preparation_phase(&mut self, state: &CombatState) {
     platform::show_prompt("Press enter to fight! ");
-    platform::read_input().map(|_| {
-      self.prepare();
+    let state = *state;
+    self.read_input(move |game_state, _| {
+      game_state.prepare();
       println!("\n");
-      self.curr_mode = GameMode::Combat(CombatState {
+      game_state.curr_mode = GameMode::Combat(CombatState {
         phase: Battle,
-        .. *state
+        .. state
       });
     });
   }

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -72,9 +72,8 @@ impl GameState {
   }
 
   fn tick_preparation_phase(&mut self, state: &CombatState) {
-    platform::show_prompt("Press enter to fight! ");
     let state = *state;
-    self.read_input(move |game_state, _| {
+    self.ask("Press enter to fight! ", move |game_state, _| {
       game_state.prepare();
       println!("\n");
       game_state.curr_mode = GameMode::Combat(CombatState {

--- a/src/command.rs
+++ b/src/command.rs
@@ -48,13 +48,4 @@ pub trait CommandProcessor<T> {
     println!("I have no idea what you're talking about.");
     return None;
   }
-
-  fn get() -> Option<T> {
-    platform::show_prompt(Self::prompt());
-
-    match platform::read_input() {
-      Some(input) => Self::get_from_input(input),
-      None => None
-    }
-  }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -29,32 +29,32 @@ pub trait CommandProcessor<T> {
     }
   }
 
+  fn get_from_input(input: String) -> Option<T> {
+    platform::hide_prompt();
+    match input.chars().next() {
+      Some(k) => {
+        let k = k.to_ascii_lowercase();
+        if k == 'h' || k == '?' {
+          println!("Here's what I understand right now:\n");
+          Self::show_help();
+          println!("");
+          return None;
+        } else if let Some(cmd) = Self::from_char(k) {
+          return Some(cmd);
+        }
+      },
+      None => {}
+    }
+    println!("I have no idea what you're talking about.");
+    return None;
+  }
+
   fn get() -> Option<T> {
     platform::show_prompt(Self::prompt());
 
     match platform::read_input() {
-      Some(input) => {
-        platform::hide_prompt();
-        match input.chars().next() {
-          Some(k) => {
-            let k = k.to_ascii_lowercase();
-            if k == 'h' || k == '?' {
-              println!("Here's what I understand right now:\n");
-              Self::show_help();
-              println!("");
-              return None;
-            } else if let Some(cmd) = Self::from_char(k) {
-              return Some(cmd);
-            }
-          },
-          None => {}
-        }
-        println!("I have no idea what you're talking about.");
-        return None;
-      },
-      None => {
-        return None;
-      }
+      Some(input) => Self::get_from_input(input),
+      None => None
     }
   }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -21,8 +21,6 @@ pub trait CommandProcessor<T> {
 
   fn get_help() -> Vec<HelpInfo>;
 
-  fn prompt() -> &'static str { "What do you want to do? " }
-
   fn show_help() {
     for info in Self::get_help().iter() {
       println!("  {} - {}", info.key, info.desc);

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,7 +1,5 @@
 use std::ascii::AsciiExt;
 
-use platform;
-
 pub struct HelpInfo {
   key: char,
   desc: String,
@@ -28,7 +26,6 @@ pub trait CommandProcessor<T> {
   }
 
   fn get_from_input(input: String) -> Option<T> {
-    platform::hide_prompt();
     match input.chars().next() {
       Some(k) => {
         let k = k.to_ascii_lowercase();

--- a/src/debug_mode.rs
+++ b/src/debug_mode.rs
@@ -41,15 +41,15 @@ impl GameState {
   pub fn tick_debug_mode(&mut self) {
     platform::show_prompt("debug> ");
 
-    platform::read_input().map(|input| {
+    self.read_input(|state, input| {
       if input == "q" || input == "quit" {
-        self.set_mode(GameMode::Primary);
+        state.set_mode(GameMode::Primary);
       } else if input == "h" || input == "?" || input == "help" {
-        self.print_help();
+        state.print_help();
       } else if input == "rooms" {
-        self.list_rooms();
+        state.list_rooms();
       } else if input.starts_with("goto ") {
-        self.goto_room(input.split_whitespace().skip(1).collect());
+        state.goto_room(input.split_whitespace().skip(1).collect());
       } else if input.len() > 0 {
         println!("Unrecognized command. Type ? for help.");
       }

--- a/src/debug_mode.rs
+++ b/src/debug_mode.rs
@@ -1,4 +1,3 @@
-use platform;
 use sized_enum::SizedEnum;
 use enum_primitive::FromPrimitive;
 use game_map::{RoomId};
@@ -39,9 +38,7 @@ impl GameState {
   }
 
   pub fn tick_debug_mode(&mut self) {
-    platform::show_prompt("debug> ");
-
-    self.read_input(|state, input| {
+    self.ask("debug> ", |state, input| {
       if input == "q" || input == "quit" {
         state.set_mode(GameMode::Primary);
       } else if input == "h" || input == "?" || input == "help" {

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -211,13 +211,15 @@ impl GameState {
           platform::hide_prompt();
           self.input_callback = None;
           cb(self, input);
+          // Note that at this point, self.input_callback may be
+          // set again, if the callback asked for input again.
         },
         None => {
           // We're probably running in the browser and there's currently
-          // no input to process, so just return.
-          return;
+          // no input to process.
         }
       }
+      return;
     }
 
     if self.strength < 1 { self.die() }

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -134,7 +134,6 @@ impl GameState {
   }
 
   pub fn pause() {
-    platform::hide_prompt();
     platform::sleep(PAUSE_MS);
   }
 
@@ -151,7 +150,6 @@ impl GameState {
       if input.len() == 0 {
         println!("Pardon me?");
       } else {
-        platform::hide_prompt();
         state.player_name = input;
         state.set_mode(GameMode::Primary);
       }
@@ -180,7 +178,6 @@ impl GameState {
             state.accuse_player_of_cheating();
             state.set_mode(GameMode::Primary);
           } else {
-            platform::hide_prompt();
             println!("After some munching, you feel stronger.");
             state.food -= amount;
             state.strength += amount * STRENGTH_PER_FOOD;
@@ -211,6 +208,7 @@ impl GameState {
     if let Some(ref cb) = input_cb {
       match platform::read_input() {
         Some(input) => {
+          platform::hide_prompt();
           self.input_callback = None;
           cb(self, input);
         },

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -76,6 +76,12 @@ impl GameState {
     }
   }
 
+  pub fn ask<F>(&mut self, question: &str, cb: F)
+      where F: 'static + Fn(&mut GameState, String) {
+    platform::show_prompt(question);
+    self.read_input(cb);
+  }
+
   pub fn read_input<F>(&mut self, cb: F)
       where F: 'static + Fn(&mut GameState, String) {
     assert!(self.input_callback.is_none(),
@@ -147,9 +153,7 @@ impl GameState {
   }
 
   fn tick_ask_name_mode(&mut self) {
-    platform::show_prompt("What is your name, explorer? ");
-
-    self.read_input(|state, input| {
+    self.ask("What is your name, explorer? ", |state, input| {
       if input.len() == 0 {
         println!("Pardon me?");
       } else {
@@ -166,9 +170,7 @@ impl GameState {
       self.show_desc = false;
     }
 
-    platform::show_prompt("How many do you want to eat? ");
-
-    self.read_input(|state, input| {
+    self.ask("How many do you want to eat? ", |state, input| {
       match input.parse::<i32>() {
         Ok(amount) => {
           if amount < 0 {

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -28,6 +28,10 @@ pub enum GameMode {
 // into them instead of expecting 'self' to be captured into their
 // closure, because the latter leads to all kinds of lifetime
 // headaches.
+//
+// Note also that this should probably be a FnOnce rather than
+// an Fn, since it only gets called once, but that doing that
+// is hard right now: https://github.com/rust-lang/rust/issues/28796
 type InputCallback = Fn(&mut GameState, String);
 
 pub struct GameState {

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -167,7 +167,7 @@ impl GameState {
 
     platform::show_prompt("How many do you want to eat? ");
 
-    platform::read_input().map(|input| {
+    self.read_input(|state, input| {
       match input.parse::<i32>() {
         Ok(amount) => {
           if amount < 0 {
@@ -175,22 +175,22 @@ impl GameState {
           } else if amount == 0 {
             println!("Fine, be that way.");
             Self::pause();
-            self.set_mode(GameMode::Primary);
-          } else if amount > self.food {
-            self.accuse_player_of_cheating();
-            self.set_mode(GameMode::Primary);
+            state.set_mode(GameMode::Primary);
+          } else if amount > state.food {
+            state.accuse_player_of_cheating();
+            state.set_mode(GameMode::Primary);
           } else {
             platform::hide_prompt();
             println!("After some munching, you feel stronger.");
-            self.food -= amount;
-            self.strength += amount * STRENGTH_PER_FOOD;
-            self.set_mode(GameMode::Primary);
+            state.food -= amount;
+            state.strength += amount * STRENGTH_PER_FOOD;
+            state.set_mode(GameMode::Primary);
             Self::pause();
           }
         },
         Err(_) => {
           println!("That does not even look like a number, {}.",
-                   self.player_name);
+                   state.player_name);
         }
       }
     });

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -50,6 +50,7 @@ pub struct GameState {
   pub curr_room: RoomId,
   pub show_desc: bool,
   input_callback: Option<Box<InputCallback>>,
+  is_processing_input: bool,
   last_input_prompt: String,
   read_input_again: bool,
 }
@@ -74,6 +75,7 @@ impl GameState {
       light: false,
       show_desc: true,
       input_callback: None,
+      is_processing_input: false,
       last_input_prompt: String::from(""),
       read_input_again: false,
     }
@@ -85,6 +87,8 @@ impl GameState {
   }
 
   pub fn ask_again(&mut self) {
+    assert_eq!(self.is_processing_input, true,
+               "This method must be called from an input callback");
     self.read_input_again = true;
   }
 
@@ -233,6 +237,7 @@ impl GameState {
     ::std::mem::swap(&mut input_cb, &mut self.input_callback);
 
     if let Some(ref cb) = input_cb {
+      self.is_processing_input = true;
       match platform::read_input() {
         Some(input) => {
           platform::hide_prompt();
@@ -245,6 +250,7 @@ impl GameState {
           // no input to process.
         }
       }
+      self.is_processing_input = false;
       input_processed = true;
     }
 

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -2,7 +2,6 @@ use game_state::{GameState, GameMode};
 use command::{CommandProcessor, HelpInfo};
 use items::Item;
 use items::Item::*;
-use platform;
 
 use self::InventoryCommand::*;
 
@@ -85,9 +84,7 @@ impl GameState {
       self.show_desc = false;
     }
 
-    platform::show_prompt("What do you want to buy? ");
-
-    self.read_input(|state, input| {
+    self.ask("What do you want to buy? ", |state, input| {
       if let Some(cmd) = InventoryCommand::get_from_input(input) {
         state.process_inventory_cmd(cmd);
       }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -12,8 +12,6 @@ pub enum InventoryCommand {
 }
 
 impl CommandProcessor<InventoryCommand> for InventoryCommand {
-  fn prompt() -> &'static str { "What do you want to buy? " }
-
   fn get_help() -> Vec<HelpInfo> {
     let buy = |item: Item| format!("buy {} (${})", item, item.price());
 
@@ -87,7 +85,7 @@ impl GameState {
       self.show_desc = false;
     }
 
-    platform::show_prompt(InventoryCommand::prompt());
+    platform::show_prompt("What do you want to buy? ");
 
     self.read_input(|state, input| {
       if let Some(cmd) = InventoryCommand::get_from_input(input) {

--- a/src/primary_mode.rs
+++ b/src/primary_mode.rs
@@ -210,9 +210,7 @@ impl GameState {
       self.show_desc = false;
     }
 
-    platform::show_prompt("What do you want to do? ");
-
-    self.read_input(|state, input| {
+    self.ask("What do you want to do? ", |state, input| {
       if let Some(cmd) = PrimaryCommand::get_from_input(input) {
         state.process_cmd(cmd);
       };

--- a/src/primary_mode.rs
+++ b/src/primary_mode.rs
@@ -210,6 +210,8 @@ impl GameState {
       self.show_desc = false;
     }
 
+    platform::show_prompt(PrimaryCommand::prompt());
+
     self.read_input(|state, input| {
       if let Some(cmd) = PrimaryCommand::get_from_input(input) {
         state.process_cmd(cmd);

--- a/src/primary_mode.rs
+++ b/src/primary_mode.rs
@@ -210,7 +210,7 @@ impl GameState {
       self.show_desc = false;
     }
 
-    platform::show_prompt(PrimaryCommand::prompt());
+    platform::show_prompt("What do you want to do? ");
 
     self.read_input(|state, input| {
       if let Some(cmd) = PrimaryCommand::get_from_input(input) {


### PR DESCRIPTION
This refactors the way the game handles input to ensure better parity between console and web builds, and also make it easier to prompt the user without having to explicitly create new `GameMode` enum values.

It does this primarily by adding two new methods to `GameState`:

* **ask(question, callback)** asks the user the given question and calls the given callback when the user has submitted their input.

  The callback takes arguments `(state, input)` where `state` is the same `GameState` instance that `ask()` was invoked on, and `input` is the string the user input.

  The `state` argument is an unfortunate workaround: closure-based callbacks referencing `self` resulted in massive lifetime headaches that I didn't know how to work around, so it was easier to just pass-in the identical `GameState` instance as an argument and never have the closure refer to `self`.  (Interestingly, I couldn't even call the argument `self` in the closure--I was hoping to just shadow `self` via the passed-in argument, but the compiler didn't like that.)

* **ask_again()** can be called from the callback passed to `ask()` and just re-prompts the user, calling the same callback again.  I did this partly because it's a convenient API, and partly because binding the callback to a variable via `let` and then having the callback re-schedule itself via `ask()` resulted in weird compiler errors that I didn't fully understand.

  I was thinking about just having `ask()` callbacks return a value indicating whether they wanted to be re-run or not. However, I thought it might be cumbersome to have the callbacks *always* return an explicit value indicating this, I decided to make it a method instead.
